### PR TITLE
BASIQ-67: Console error on first landing

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -80,7 +80,7 @@ const Home = () => {
                 )}
                 {/* ACTION */}
                 <Link href="/account-verification" passHref>
-                  <Button as="a" variant="bold" block>
+                  <Button variant="bold" block>
                     {basiqConnectionInProgress || basiqConnectionSuccess ? 'Continue setup' : 'Get started'}
                   </Button>
                 </Link>


### PR DESCRIPTION
It's an HTML rule violation error bro, there can't be another <a> tag between the <a> </a> tag, I searched index.js because it is on the first page. If <Button as="a" /> with the "as" attribute tries to render the <Button> component with the <a> tag, this will break the HTML rule. Because the button <button> and link <a> tags are designed for different purposes and are not interchangeable.